### PR TITLE
chore: add node_metadata option to conf template

### DIFF
--- a/templates/consul/config.json.j2
+++ b/templates/consul/config.json.j2
@@ -3,6 +3,10 @@
     {% if consul_node_name is defined %}
     "node_name": "{{ consul_node_name }}",
     {% endif %}
+    {% if consul_node_meta is defined %}
+    "node_meta":
+    {{ consul_node_meta | to_json }},
+    {% endif %}
     "datacenter": "{{ consul_datacenter }}",
     "domain": "{{ consul_domain }}",
 


### PR DESCRIPTION
example:

```yml
consul_node_meta:
   role: database
```